### PR TITLE
fix: specify missing dependency on qiskit-aer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "qiskit>=2.1.2, <3",
     "numpy>=1.26",
     "qiskit-ibm-runtime>=0.38",
+    "qiskit-aer>=0.17",
 ]
 
 [tool.maturin]


### PR DESCRIPTION
This was missed during #3.