### PR TITLE
Add integration coverage for Pauli propagation workflows

### DIFF
--- a/test/test_propagation.py
+++ b/test/test_propagation.py
@@ -12,9 +12,139 @@
 
 """Test propagation module."""
 
+from __future__ import annotations
+
+import math
+import numpy as np
 import unittest
+
+from numpy.testing import assert_allclose
+from qiskit.circuit import QuantumCircuit
+from qiskit.circuit.library import RZZGate
+from qiskit.quantum_info import Operator, PauliList, SparsePauliOp
+
+from pauli_prop import (
+    circuit_to_rotation_gates,
+    evolve_through_cliffords,
+    propagate_through_circuit,
+    propagate_through_operator,
+    propagate_through_rotation_gates,
+)
+
+
+def _pauli_dict(op: SparsePauliOp) -> dict[str, complex]:
+    """Helper returning a label -> coefficient mapping."""
+
+    simplified = op.simplify(atol=1e-12)
+    paulis = simplified.paulis.to_labels()
+    coeffs = simplified.coeffs.astype(complex)
+    return {label: coeff for label, coeff in zip(paulis, coeffs)}
 
 
 class TestPropagation(unittest.TestCase):
-    def test_propagate_through_circuit(self):
-        pass
+    """Tests covering the most visible Pauli propagation entry points."""
+
+    def test_propagate_through_circuit_matches_matrix(self):
+        """The Rust accelerated evolution should agree with matrix conjugation."""
+
+        circuit = QuantumCircuit(1)
+        circuit.ry(math.pi / 3, 0)
+        operator = SparsePauliOp.from_list([("Z", 1.0)])
+
+        evolved, trunc_norm = propagate_through_circuit(
+            operator, circuit, max_terms=8, atol=1e-12, frame="s"
+        )
+
+        unitary = Operator(circuit).data
+        expected_matrix = unitary @ operator.to_matrix() @ unitary.conj().T
+        expected = SparsePauliOp.from_operator(expected_matrix, atol=1e-12, rtol=0.0)
+
+        self.assertEqual(trunc_norm, 0.0)
+        evolved_dict = _pauli_dict(evolved)
+        expected_dict = _pauli_dict(expected)
+        self.assertSetEqual(set(evolved_dict.keys()), set(expected_dict.keys()))
+        evolved_coeffs = np.array([evolved_dict[key] for key in sorted(evolved_dict)])
+        expected_coeffs = np.array([expected_dict[key] for key in sorted(expected_dict)])
+        assert_allclose(evolved_coeffs, expected_coeffs)
+
+    def test_propagate_through_rotation_gates_heisenberg(self):
+        """Heisenberg frame evolution should align with direct calculation."""
+
+        circuit = QuantumCircuit(1)
+        circuit.rx(math.pi / 7, 0)
+        rot_gates = circuit_to_rotation_gates(circuit)
+        operator = SparsePauliOp.from_list([("X", 0.75), ("Z", -0.25)])
+
+        evolved, trunc_norm = propagate_through_rotation_gates(
+            operator, rot_gates, max_terms=8, atol=1e-12, frame="h"
+        )
+
+        unitary = Operator(circuit).data
+        expected_matrix = unitary.conj().T @ operator.to_matrix() @ unitary
+        expected = SparsePauliOp.from_operator(expected_matrix, atol=1e-12, rtol=0.0)
+
+        self.assertEqual(trunc_norm, 0.0)
+        evolved_dict = _pauli_dict(evolved)
+        expected_dict = _pauli_dict(expected)
+        self.assertSetEqual(set(evolved_dict.keys()), set(expected_dict.keys()))
+        evolved_coeffs = np.array([evolved_dict[key] for key in sorted(evolved_dict)])
+        expected_coeffs = np.array([expected_dict[key] for key in sorted(expected_dict)])
+        assert_allclose(evolved_coeffs, expected_coeffs)
+
+    def test_evolve_through_cliffords_decomposition(self):
+        """The returned Clifford and remainder circuit should reconstruct the input."""
+
+        circuit = QuantumCircuit(2)
+        circuit.h(0)
+        circuit.cx(0, 1)
+        circuit.append(RZZGate(math.pi / 5), [0, 1])
+        circuit.s(1)
+
+        clifford, non_cliffords = evolve_through_cliffords(circuit)
+
+        reconstructed = Operator(non_cliffords).data @ Operator(clifford.to_circuit()).data
+        expected = Operator(circuit).data
+
+        assert_allclose(reconstructed, expected)
+
+        # All instructions in the remainder should be Pauli rotations.
+        allowed_ops = {"rzx", "rzz", "pauli_evolution", "PauliEvolution"}
+        for inst in non_cliffords:
+            self.assertIn(inst.operation.name, allowed_ops)
+
+    def test_propagate_through_operator_exact_and_traceless(self):
+        """Exact propagation should agree with matrix conjugation and support traceless outputs."""
+
+        op1 = SparsePauliOp.from_list([(label, coeff) for label, coeff in [("I", 0.2), ("Z", 0.6)]])
+        op2 = SparsePauliOp.from_list([(label, coeff) for label, coeff in [("X", 0.5), ("Z", 1.0)]])
+
+        evolved = propagate_through_operator(op1, op2, max_terms=None, coerce_op1_traceless=True)
+
+        matrix_evolved = op2.to_matrix() @ op1.to_matrix() @ op2.to_matrix().conj().T
+        expected = SparsePauliOp.from_operator(matrix_evolved, atol=1e-12, rtol=0.0)
+        expected = expected.simplify(atol=1e-12)
+        expected = expected[1:]  # remove the identity term
+
+        evolved_dict = _pauli_dict(evolved)
+        expected_dict = _pauli_dict(expected)
+        self.assertSetEqual(set(evolved_dict.keys()), set(expected_dict.keys()))
+        evolved_coeffs = np.array([evolved_dict[key] for key in sorted(evolved_dict)])
+        expected_coeffs = np.array([expected_dict[key] for key in sorted(expected_dict)])
+        assert_allclose(evolved_coeffs, expected_coeffs)
+
+    def test_propagate_through_operator_truncation(self):
+        """When a cutoff is requested the operator should be truncated accordingly."""
+
+        op1 = SparsePauliOp(PauliList(["X", "Y"]), coeffs=[0.5, 0.5])
+        op2 = SparsePauliOp(PauliList(["X", "Y", "Z"]), coeffs=[1.0, 0.8, 0.6])
+
+        truncated = propagate_through_operator(
+            op1, op2, max_terms=2, frame="s", atol=0.0, search_step=1
+        )
+
+        self.assertLessEqual(len(truncated), 2)
+        self.assertTrue(any(label != "I" for label in truncated.paulis.to_labels()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_propagation.py
+++ b/test/test_propagation.py
@@ -123,10 +123,12 @@ class TestPropagation(unittest.TestCase):
         matrix_evolved = op2.to_matrix() @ op1.to_matrix() @ op2.to_matrix().conj().T
         expected = SparsePauliOp.from_operator(matrix_evolved, atol=1e-12, rtol=0.0)
         expected = expected.simplify(atol=1e-12)
-        expected = expected[1:]  # remove the identity term
 
         evolved_dict = _pauli_dict(evolved)
+        self.assertNotIn("I", evolved_dict)
+
         expected_dict = _pauli_dict(expected)
+        expected_dict.pop("I", None)
         self.assertSetEqual(set(evolved_dict.keys()), set(expected_dict.keys()))
         evolved_coeffs = np.array([evolved_dict[key] for key in sorted(evolved_dict)])
         expected_coeffs = np.array([expected_dict[key] for key in sorted(expected_dict)])


### PR DESCRIPTION
Changes:
- Added comprehensive integration tests that cover circuit-based propagation, rotation-gate workflows, Clifford separation, and operator conjugation, with numeric comparison helpers for SparsePauliOp outputs.