### PR TITLE
Update proper metadata in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "maturin>=1.0,<2.0",
-    "setuptools>=45",
-    "setuptools_scm[toml]>=6.2",
+    "setuptools>=77.0.3",
 ]
 build-backend = "maturin"
 


### PR DESCRIPTION
Changes:
- Updated `license` metadata in `pyproject.toml` according to [PEP 639](https://peps.python.org/pep-0639/).
- [PEP 639 (“Improving License Clarity with Better Package Metadata”)](https://peps.python.org/pep-0639/) defines a clearer, more modern way to declare licenses in Python project metadata.

*EDIT: We need to update minimum version of `maturin>=1.9` to make this applicable, since [`maturin` version `1.9.0` introduced PEP 639 while `1.9.2`-`1.9.3` polished it](https://www.maturin.rs/changelog.html)*