### PR TITLE
Remove hatch configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,14 +89,6 @@ parallel = true
 fail_under = 100
 show_missing = true
 
-[tool.hatch.build.targets.wheel]
-only-include = [
-    "pauli_prop",
-]
-
-[tool.hatch.metadata]
-allow-direct-references = true
-
 [tool.mypy]
 python_version = "3.10"
 show_error_codes = true


### PR DESCRIPTION
This removes some settings for hatch, some of which are already outdated, and none of which are still relevant since we are using maturin as our build system.