### PR TITLE
Use time.perf_counter instead of time.time for timing

### DIFF
--- a/docs/tutorials/01_classically_estimate_expectation_values.ipynb
+++ b/docs/tutorials/01_classically_estimate_expectation_values.ipynb
@@ -119,12 +119,12 @@
     "approx_evs = []\n",
     "durations = []\n",
     "for max_terms in max_terms_list:\n",
-    "    st = time.time()\n",
+    "    st = time.perf_counter()\n",
     "    evolved_obs = propagate_through_circuit(\n",
     "        observable, non_cliff, max_terms=max_terms, atol=1e-12, frame=\"h\"\n",
     "    )[0]\n",
     "    evolved_obs.paulis = evolved_obs.paulis.evolve(cliff, frame=\"h\")\n",
-    "    durations.append(time.time() - st)\n",
+    "    durations.append(time.perf_counter() - st)\n",
     "    approx_evs.append(float(evolved_obs.coeffs[~evolved_obs.paulis.x.any(axis=1)].sum()))"
    ]
   },

--- a/docs/tutorials/02_simulate_127Q_kicked_ising.ipynb
+++ b/docs/tutorials/02_simulate_127Q_kicked_ising.ipynb
@@ -106,9 +106,9 @@
     "times = []\n",
     "approx_evs = []\n",
     "for circuit in circuits:\n",
-    "    st = time.time()\n",
+    "    st = time.perf_counter()\n",
     "    propagated_obs = propagate_through_circuit(observable, circuit, 100_000, 1e-5, frame=\"h\")[0]\n",
-    "    times.append(time.time() - st)\n",
+    "    times.append(time.perf_counter() - st)\n",
     "    approx_evs.append(float(propagated_obs.coeffs[~propagated_obs.paulis.x.any(axis=1)].sum()))\n",
     "print(f\"Finshed {len(circuits)} simulations in {sum(times):.0f}s\")"
    ]


### PR DESCRIPTION
`time.time` should not be used for measuring durations because it is not guaranteed to be monotonic, see https://docs.python.org/3/library/time.html#time.time.